### PR TITLE
Ensure cflags are passed to clang

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -11,7 +11,10 @@
       ],
       "sources": ["src/constants.cc", "src/cld.cc"],
       "defines": [],
-      "cflags_cc": ["-Wall"]
+      "cflags_cc": ["-Wall"],
+      "xcode_settings": {
+        "OTHER_CFLAGS": ["-Wall"]
+      }
     }
   ]
 }

--- a/cld/binding.gyp
+++ b/cld/binding.gyp
@@ -33,7 +33,10 @@
         "internal/cld_generated_score_quad_octa_0122.cc"
       ],
       "defines": [],
-      "cflags_cc": ["-w"]
+      "cflags_cc": ["-w"],
+      "xcode_settings": {
+        "OTHER_CFLAGS": ["-w"]
+      }
     }
   ]
 }

--- a/src/cld.cc
+++ b/src/cld.cc
@@ -113,7 +113,6 @@ namespace NodeCld {
       NodeCldDetected rawLanguage = rawDetected->at(i);
       detected->Set(static_cast<uint32_t>(i), NanNew<v8::String>(rawLanguage.name));
     }
-    //NanAssignPersistent(detected, NanNew<v8::Array>());
     target->Set(NanNew<v8::String>("DETECTED_LANGUAGES"), detected);
 
     // set all languages
@@ -123,7 +122,6 @@ namespace NodeCld {
       NodeCldLanguage rawLanguage = rawLanguages->at(i);
       languages->Set(NanNew<v8::String>(rawLanguage.name), NanNew<v8::String>(rawLanguage.code));
     }
-    //NanAssignPersistent(languages, NanNew<v8::Object>());
     target->Set(NanNew<v8::String>("LANGUAGES"), languages);
 
     // set encodings
@@ -133,7 +131,6 @@ namespace NodeCld {
       NodeCldEncoding rawEncoding = rawEncodings->at(i);
       encodings->Set(static_cast<uint32_t>(i), NanNew<v8::String>(rawEncoding.name));
     }
-    //NanAssignPersistent(encodings, NanNew<v8::Array>());
     target->Set(NanNew<v8::String>("ENCODINGS"), encodings);
 
     NODE_SET_METHOD(target, "detect", Detect);


### PR DESCRIPTION
This commit silences CLD2 compiler warnings when `npm install`ing on a Mac, plus removes some commented-out code I left in the previous commit. Thank you!
