### PR TITLE
Add postinstall cleanup hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "nan": "^1.2.0"
   },
   "scripts": {
-    "test": "node test/runner.js"
+    "test": "node test/runner.js",
+    "postinstall": "rm -r ./deps/ && find ./build -type f | grep -v 'cld.node' | xargs -I{} rm {}"
   },
   "author": {
     "name": "Blagovest Dachev",


### PR DESCRIPTION
Cleanup useless build files and source code. Reduces the install size from 121mb to 7mb.

A lighter install is great when deploying to Heroku (smaller slug) and when building Docker containers.

With this PR we win an extra ~114mb at no cost.