### PR TITLE
Don't destroy symbols file (.pdb) in postinstall.js

### DIFF
--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -15,7 +15,7 @@ function deleteBuildFiles(cb) {
     }
 
     files = _.reject(files, function(val, key) {
-      return /cld\.node$/.test(val)
+      return /cld\.(node|pdb)$/.test(val)
     });
 
     for (var i = 0; i < files.length; i++) {


### PR DESCRIPTION
Fixes https://github.com/dachev/node-cld/issues/46