### PR TITLE
Statically link libstdc++ to support AWS Lambda

### DIFF
--- a/deps/cld/binding.gyp
+++ b/deps/cld/binding.gyp
@@ -41,7 +41,7 @@
       "cflags_cc": ["-w", "-std=gnu++98"],
       "cflags_cc!": ["-std=gnu++0x"],
       "link_settings" : {
-        "ldflags": ["-z", "muldefs"]
+        "ldflags": ["-z", "muldefs", "-static-libstdc++"]
       },
       "xcode_settings": {
         "OTHER_CFLAGS": ["-w"],


### PR DESCRIPTION
AWS Lambda has older libraries which can't be updated. Statically linking `libstdc++` makes this package usable on Lambda.

Currently I'm solving this by installing the fixed NPM module directly from my fork.
```
"dependencies": {
  "cld": "git+https://git@github.com/mrtcode/node-cld#931f6e6",
  ...
```