### PR TITLE
require cld module with node suffix to work with webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var _    = require('underscore');
-var cld2 = require('./build/Release/cld');
+var cld2 = require('./build/Release/cld.node');
 
 module.exports = {
   LANGUAGES          : cld2.LANGUAGES,


### PR DESCRIPTION
by packaging my application with webpack I run into the following error message: 

ERROR in ./node_modules/@paulcbetts/cld/index.js
Module not found: Error: Can't resolve './build/Release/cld' in '/Users/owolf/git/knowledge-transfer-tool/node_modules/@paulcbetts/cld'
 @ ./node_modules/@paulcbetts/cld/index.js 2:11-41
 @ ./node_modules/electron-spellchecker/lib/cld2.js
 @ ./node_modules/electron-spellchecker/lib/spell-check-handler.js
 @ ./node_modules/electron-spellchecker/lib/index.js
 @ ./src/windows/editor/index.js

This is also described here:  https://github.com/electron-userland/electron-spellchecker/issues/94 

I have been able to get rid of this message by applying this commit.