### PR TITLE
Rewrite cld to actually be async with a promise API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,25 @@ Linux users, make sure you have g++ >= 4.8. If this is not an option, you should
 ## Examples
 ### Simple
 ```js
-require('cld').detect('This is a language recognition example', function(err, result) {
+const cld = require('cld');
+
+// As a promise
+cld.detect('This is a language recognition example').then((result) => {
   console.log(result);
 });
+
+// In an async function
+async function testCld() {
+  const result = await cld.detect('This is a language recognition example');
+  console.log(result);
+}
 ```
 
 ### Advanced
 ```js
-var text    = 'Това е пример за разпознаване на Български език';
-var options = {
+const cld = require('cld');
+const text     = 'Това е пример за разпознаване на Български език';
+const options  = {
   isHTML       : false,
   languageHint : 'BULGARIAN',
   encodingHint : 'ISO_8859_5',
@@ -35,11 +45,27 @@ var options = {
   httpHint     : 'bg'
 };
 
-require('cld').detect(text, options, function(err, result) {
+// As a promise
+cld.detect(text, options).then((result) => {
+  console.log(result);
+});
+
+// In an async function
+async function testCld() {
+  const result = await cld.detect(text, options);
+  console.log(result);
+}
+```
+
+### Legacy
+Detect can be called leveraging the node callback pattern. If options are provided, the third parameter should be the callback.
+```javascript
+const cld = require('cld');
+
+cld.detect('This is a language recognition example', (err, result) => {
   console.log(result);
 });
 ```
-
 
 ## Options
 

--- a/src/cld.cc
+++ b/src/cld.cc
@@ -1,3 +1,6 @@
+#include <memory>
+#include <string>
+
 #include "compact_lang_det.h"
 #include "encodings.h"
 #include "constants.h"
@@ -9,73 +12,97 @@ using std::unexpected_handler;
 #include <napi.h>
 
 namespace NodeCld {
-  Napi::Object Detect(const Napi::CallbackInfo& info) {
-    auto env = info.Env();
+  struct CLDInput {
+    std::string bytes,
+      languageHint,
+      encodingHint,
+      tldHint,
+      httpHint;
+    int numBytes;
+    bool isPlainText;
+  };
 
-    std::string text = info[0].ToString().Utf8Value();
-    const char *bytes = text.c_str();
-    int numBytes = text.length();
-    bool isPlainText = info[1].ToBoolean();
-
-    CLD2::CLDHints hints;
-    hints.tld_hint = 0;
-    hints.content_language_hint = 0;
-    hints.language_hint = CLD2::UNKNOWN_LANGUAGE;
-    hints.encoding_hint = CLD2::UNKNOWN_ENCODING;
-
-
-    if (info[2].IsString()) {
-      std::string languageHint = info[2].ToString().Utf8Value();
-      if (languageHint.length() > 0) {
-        hints.language_hint = Constants::getInstance().getLanguageFromName(languageHint.c_str());
-      }
-    }
-
-    if (info[3].IsString()) {
-      std::string encodingHint = info[3].ToString().Utf8Value();
-      if (encodingHint.length() > 0) {
-        hints.encoding_hint = Constants::getInstance().getEncodingFromName(encodingHint.c_str());
-      }
-    }
-
-    if (info[4].IsString()) {
-      std::string tldHint = info[4].ToString().Utf8Value();
-      if (tldHint.length() > 0) {
-        hints.tld_hint = tldHint.c_str();
-      }
-    }
-
-    if (info[5].IsString()) {
-      std::string httpHint = info[5].ToString().Utf8Value();
-      if (httpHint.length() > 0) {
-        hints.content_language_hint = httpHint.c_str();
-      }
-    }
-
+  struct CLDOutput {
     CLD2::Language language3[3];
     int percent3[3];
     double normalized_score3[3];
     CLD2::ResultChunkVector resultChunkVector;
     int textBytesFound;
     bool isReliable;
+  };
+
+  std::unique_ptr<CLDInput> UnpackInputFromJSArgs(const Napi::CallbackInfo &info) {
+    std::unique_ptr<CLDInput> input(new CLDInput);
+
+    input->bytes = info[0].ToString().Utf8Value();
+    input->numBytes = input->bytes.length();
+    input->isPlainText = info[1].ToBoolean();
+
+    if (info[2].IsString()) {
+      input->languageHint = info[2].ToString().Utf8Value();
+    }
+
+    if (info[3].IsString()) {
+      input->encodingHint = info[3].ToString().Utf8Value();
+    }
+
+    if (info[4].IsString()) {
+      input->tldHint = info[4].ToString().Utf8Value();
+    }
+
+    if (info[5].IsString()) {
+      input->httpHint = info[5].ToString().Utf8Value();
+    }
+
+    return input;
+  }
+
+  std::unique_ptr<CLDOutput> DetectLanguage(std::unique_ptr<CLDInput> input) {
+    std::unique_ptr<CLDOutput> output(new CLDOutput);
+    CLD2::CLDHints hints;
+    hints.tld_hint = 0;
+    hints.content_language_hint = 0;
+    hints.language_hint = CLD2::UNKNOWN_LANGUAGE;
+    hints.encoding_hint = CLD2::UNKNOWN_ENCODING;
+
+    if (input->languageHint.length() > 0) {
+      hints.language_hint = Constants::getInstance().getLanguageFromName(input->languageHint.c_str());
+    }
+
+    if (input->encodingHint.length() > 0) {
+      hints.encoding_hint = Constants::getInstance().getEncodingFromName(input->encodingHint.c_str());
+    }
+
+    if (input->tldHint.length() > 0) {
+      hints.tld_hint = input->tldHint.c_str();
+    }
+
+    if (input->httpHint.length() > 0) {
+      hints.content_language_hint = input->httpHint.c_str();
+    }
 
     CLD2::ExtDetectLanguageSummary(
-      bytes, numBytes,
-      isPlainText,
+      input->bytes.c_str(),
+      input->numBytes,
+      input->isPlainText,
       &hints,
       0,
-      language3,
-      percent3,
-      normalized_score3,
-      &resultChunkVector,
-      &textBytesFound,
-      &isReliable
+      output->language3,
+      output->percent3,
+      output->normalized_score3,
+      &output->resultChunkVector,
+      &output->textBytesFound,
+      &output->isReliable
     );
 
+    return output;
+  }
+
+  Napi::Object UnpackOutputToJS(const Napi::Env env, std::unique_ptr<CLDOutput> output) {
     size_t languageIdx = 0;
     auto languages = Napi::Array::New(env);
     for (size_t resultIdx = 0; resultIdx < 3; resultIdx++) {
-      CLD2::Language lang = language3[resultIdx];
+      CLD2::Language lang = output->language3[resultIdx];
 
       if (lang == CLD2::UNKNOWN_LANGUAGE) {
         continue;
@@ -84,16 +111,16 @@ namespace NodeCld {
       auto item = Napi::Object::New(env);
       item["name"] = Napi::String::New(env, Constants::getInstance().getLanguageName(lang));
       item["code"] = Napi::String::New(env, Constants::getInstance().getLanguageCode(lang));
-      item["percent"] = Napi::Number::New(env, percent3[resultIdx]);
-      item["score"] = Napi::Number::New(env, normalized_score3[resultIdx]);
+      item["percent"] = Napi::Number::New(env, output->percent3[resultIdx]);
+      item["score"] = Napi::Number::New(env, output->normalized_score3[resultIdx]);
 
       languages[languageIdx++] = item;
     }
 
     size_t chunkIdx = 0;
     auto chunks = Napi::Array::New(env);
-    for (size_t resultIdx = 0; resultIdx < resultChunkVector.size(); resultIdx++) {
-      CLD2::ResultChunk chunk = resultChunkVector.at(resultIdx);
+    for (size_t resultIdx = 0; resultIdx < output->resultChunkVector.size(); resultIdx++) {
+      CLD2::ResultChunk chunk = output->resultChunkVector.at(resultIdx);
       CLD2::Language lang = static_cast<CLD2::Language>(chunk.lang1);
 
       if (lang == CLD2::UNKNOWN_LANGUAGE) {
@@ -110,12 +137,49 @@ namespace NodeCld {
     }
 
     auto results = Napi::Object::New(env);
-    results["reliable"] = Napi::Boolean::New(env, isReliable);
-    results["textBytes"] = Napi::Number::New(env, textBytesFound);
+    results["reliable"] = Napi::Boolean::New(env, output->isReliable);
+    results["textBytes"] = Napi::Number::New(env, output->textBytesFound);
     results["languages"] = languages;
     results["chunks"] = chunks;
 
     return results;
+  }
+
+  class DetectAsyncWorker : public Napi::AsyncWorker {
+    public:
+      DetectAsyncWorker(const Napi::CallbackInfo &info):
+        Napi::AsyncWorker(info.Env()),
+        deferred(Napi::Promise::Deferred::New(info.Env())),
+        mInput(UnpackInputFromJSArgs(info))
+      {}
+
+      void Execute() {
+        mOutput = DetectLanguage(std::move(mInput));
+      }
+
+      void OnOK() {
+        deferred.Resolve(UnpackOutputToJS(Env(), std::move(mOutput)));
+      }
+
+      Napi::Promise Promise() {
+        this->Queue();
+        return deferred.Promise();
+      }
+
+    private:
+      Napi::Promise::Deferred deferred;
+      std::unique_ptr<CLDInput> mInput;
+      std::unique_ptr<CLDOutput> mOutput;
+  };
+
+  Napi::Object Detect(const Napi::CallbackInfo &info) {
+    auto input = UnpackInputFromJSArgs(info);
+    auto output = DetectLanguage(std::move(input));
+    return UnpackOutputToJS(info.Env(), std::move(output));
+  }
+
+  Napi::Promise DetectAsync(const Napi::CallbackInfo &info) {
+    return (new DetectAsyncWorker(info))->Promise();
   }
 
   Napi::Object Init(Napi::Env env, Napi::Object exports) {
@@ -146,7 +210,7 @@ namespace NodeCld {
     exports["ENCODINGS"] = encodings;
 
     exports["detect"] = Napi::Function::New(env, Detect);
-
+    exports["detectAsync"] = Napi::Function::New(env, DetectAsync);
     return exports;
   }
 


### PR DESCRIPTION
It looks like it might be beneficial for electron-spellchecker for this library to have a true async API. See https://github.com/electron-userland/electron-spellchecker/pull/170.

Since we were already using the node callback pattern, most users have been promisifying this call anyway. I've preserved the callback API so that it should not be a breaking change (unless someone depended on the implementation actually being synchronous).