### PR TITLE
index.d.ts: make Options properties optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,11 +11,11 @@ interface Chunk {
   readonly bytes: number;
 }
 interface Options {
-  readonly isHTML: boolean;
-  readonly languageHint: string;
-  readonly encodingHint: string;
-  readonly tldHint: string;
-  readonly httpHint: string;
+  readonly isHTML?: boolean;
+  readonly languageHint?: string;
+  readonly encodingHint?: string;
+  readonly tldHint?: string;
+  readonly httpHint?: string;
 }
 interface DetectLanguage {
   readonly reliable: boolean;


### PR DESCRIPTION
Otherwise you have to provide an object containing all properties, although
_.defaults will overwrite any property that has not been set.