### PR TITLE
support the bestEffort flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ Pass top level domain as a hint
 
 Pass an HTTP "Content-Encoding" value as a hint
 
+#### bestEffort
+
+Set to true to give best-effort answer, instead of UNKNOWN_LANGUAGE. May be useful for
+short text if the caller prefers an approximate answer over none.
+
 ## Warning
 Once the module has been installed, the underlying C sources will remain in the ```deps/cld``` folder and continue to occupy considerable space. This is because they will be required if you ever need to run `npm rebuild`. If you are under severe constraints you can delete this folder and reclam >100M
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@ interface Options {
   readonly encodingHint?: string;
   readonly tldHint?: string;
   readonly httpHint?: string;
+  readonly bestEffort?: boolean;
 }
 interface DetectLanguage {
   readonly reliable: boolean;

--- a/index.js
+++ b/index.js
@@ -27,12 +27,16 @@ module.exports = {
         languageHint : '',
         encodingHint : '',
         tldHint      : '',
-        httpHint     : ''
+        httpHint     : '',
+        bestEffort   : false
       };
       options = _.defaults({}, options, defaults);
 
       if (!_.isBoolean(options.isHTML)) {
         throw new Error('Invalid isHTML value');
+      }
+      if (!_.isBoolean(options.bestEffort)) {
+        throw new Error('Invalid bestEffort value');
       }
       if (!_.isString(options.languageHint)) {
         throw new Error('Invalid languageHint');
@@ -64,7 +68,8 @@ module.exports = {
         options.languageHint,
         options.encodingHint,
         options.tldHint,
-        options.httpHint
+        options.httpHint,
+        options.bestEffort
       );
 
       if (result.languages.length < 1) {

--- a/src/cld.cc
+++ b/src/cld.cc
@@ -19,6 +19,7 @@ namespace NodeCld {
       httpHint;
     int numBytes;
     bool isPlainText;
+    bool bestEffort;
   };
 
   struct CLDOutput {
@@ -52,6 +53,7 @@ namespace NodeCld {
     if (info[5].IsString()) {
       input->httpHint = info[5].ToString().Utf8Value();
     }
+    input->bestEffort = info[6].ToBoolean();
 
     return input;
   }
@@ -79,13 +81,17 @@ namespace NodeCld {
     if (input->httpHint.length() > 0) {
       hints.content_language_hint = input->httpHint.c_str();
     }
+    int flags = 0;
+    if (input->bestEffort) {
+      flags |= CLD2::kCLDFlagBestEffort;
+    }
 
     CLD2::ExtDetectLanguageSummary(
       input->bytes.c_str(),
       input->numBytes,
       input->isPlainText,
       &hints,
-      0,
+      flags,
       output->language3,
       output->percent3,
       output->normalized_score3,

--- a/test/runner.js
+++ b/test/runner.js
@@ -11,7 +11,7 @@ async function runCoreTests(detected) {
       return;
     }
 
-    const result = await cld.detct(val.sample);
+    const result = await cld.detect(val.sample);
     assert.equal(_.isArray(result.languages), true);
     assert.equal(result.languages.length > 0, true);
     assert.equal(val.name, result.languages[0].name);
@@ -19,6 +19,20 @@ async function runCoreTests(detected) {
     detected[val.name] = true;
   }
 }
+
+async function runBestEffortTests() {
+  for (const val of data.all) {
+    if (!val.testOnWindows) {
+      return;
+    }
+
+    const result = await cld.detect(val.sample, {bestEffort: true});
+    assert.equal(_.isArray(result.languages), true);
+    assert.equal(result.languages.length > 0, true);
+    assert.equal(val.name, result.languages[0].name);
+  }
+}
+
 
 async function runChunkTests() {
   for (const val of data.all) {
@@ -165,6 +179,7 @@ function runCrossCheckTests(detected) {
   let detected = {};
 
   await runCoreTests(detected);
+  await runBestEffortTests();
   await runChunkTests();
   await runEncodingHintTests();
   await runLanguageHintTests();


### PR DESCRIPTION
Support `CLD2::kCLDFlagBestEffort` for shorter text

Helps with issues like #78 for example:

without bestEffort
```
> console.log((await cld.detect("J'aime me beurrer la biscote")))
Uncaught Error: Failed to identify language
    at Object.detect (/Users/jgallagher/extsrc/slackhappy.gh/node-cld/index.js:76:15)
    at async REPL6:1:46
```

with bestEffort:

```
> console.log((await cld.detect("J'aime me beurrer la biscote", {bestEffort:true})))
{
  reliable: true,
  textBytes: 30,
  languages: [ { name: 'FRENCH', code: 'fr', percent: 96, score: 176 } ],
  chunks: []
}
```


Or #31 

```
> console.log((await cld.detect("beija-flor: laíla defende maior número de parcerias e critica altos gastos")))
Uncaught Error: Failed to identify language
    at Object.detect (/Users/jgallagher/extsrc/slackhappy.gh/node-cld/index.js:76:15)
    at async REPL9:1:46
```

with bestEffort:

```
> console.log((await cld.detect("beija-flor: laíla defende maior número de parcerias e critica altos gastos", {bestEffort:true})))
{
  reliable: true,
  textBytes: 77,
  languages: [ { name: 'PORTUGUESE', code: 'pt', percent: 98, score: 215 } ],
  chunks: []
}
```

#33 


```
> console.log(await cld.detect('Hi there'))
Uncaught Error: Failed to identify language
    at Object.detect (/Users/jgallagher/extsrc/slackhappy.gh/node-cld/index.js:76:15)
    at async REPL3:1:45
> 
```

with bestEffort:

```
> console.log(await cld.detect('Hi there', {bestEffort:true}))
{
  reliable: true,
  textBytes: 10,
  languages: [ { name: 'ENGLISH', code: 'en', percent: 90, score: 796 } ],
  chunks: []
}
```
